### PR TITLE
Mailgo Installation, HomePage Style Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 _Personal Blog and Portfolio built from the Sanity.io Gridsome blog template, styled with Tailwindcss._
 
-[Live Url](https://brooksfolio.netlify.app/)
+This site is used for my own personal blog and portfolio that I have extended from the Sanity.io Gridsome blog template, not only to get experience with Sanity, but also to extend my knowledge of working with Gridsome, TailwindCSS, and to have a place for me to post my personal projects that I work on as well as any blog posts that I write.
 
-Deployed from [sanity.io/create](https://www.sanity.io/create/?template=sanity-io%2Fsanity-template-gridsome-blog).
+This site also implements [mailgo](https://mailgo.dev/) which is open source module that transforms mailto and tel links to utilize a modal popup with links to open gmail, outlook, or a users default email service instead of the standard link to mail or phone services.
 
-## What you have
+Also feel free to fork this repo if you like my design as a base but do make it your own!
+
+[Live Url](https://zacharybrooks.dev/)
+
+## What the site has
 
 - A fast by default blog and Portfolio with [Gridsome](https://gridsome.org)
 - Structured content using [Sanity.io](https://www.sanity.io)
@@ -23,8 +27,8 @@ Deployed from [sanity.io/create](https://www.sanity.io/create/?template=sanity-i
 
 ## Enable real-time content preview on development
 
-1. Go to your [project’s API settings on manage.sanity.io](https://manage.sanity.io/projects/mso96qji/settings/api) and create a token with read rights.
-2. Rename `.env.development.tenplate` to `.env.development` and paste in the token: `SANITY_READ_TOKEN="yourTokenHere"`.
+1. Go to your [project’s API settings on manage.sanity.io](https://manage.sanity.io/) and create a token with read rights.
+2. Rename `.env.development.template` to `.env.development` and paste in the token: `SANITY_READ_TOKEN="yourTokenHere"`.
 3. Restart the development server (`ctrl + C` and `npm run dev`).
 
 If you want to turn off preview you can set `watchMode: false` in gridsome-config.js. If you just want to preview published changes you can set `overlayDrafts: false` in gridsome-config.js.
@@ -36,6 +40,8 @@ Netlify automatically deploys new changes commited to master on GitHub. If you w
 This starter comes with a Netlify-widget that lets you trigger new deploys from Sanity Studio.
 
 ## Stuck? Get help
+
+If you want to know more about Sanity or get help directly from the Sanity development team and community check out the links below.
 
 [![Slack Community Button](https://slack.sanity.io/badge.svg)](https://slack.sanity.io/)
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7492,6 +7492,11 @@
         }
       }
     },
+    "mailgo": {
+      "version": "0.9.14",
+      "resolved": "https://registry.npmjs.org/mailgo/-/mailgo-0.9.14.tgz",
+      "integrity": "sha512-WyQuAUdaKvBlJy5LIJ1QpLAkAMqfyFR4CX3j6yimAGY0kYG7pvacInogH7FO4wHDGDqk/FUbmvKuIoMDAxK0lg=="
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,8 @@
     "gridsome-source-sanity": "^1.0.5",
     "sanity-blocks-vue-component": "^0.1.0",
     "tailwindcss": "^1.4.6",
-    "vue-youtube": "^1.4.0"
+    "vue-youtube": "^1.4.0",
+    "mailgo": "^0.9.14"
   },
   "devDependencies": {
     "css-loader": "^2.1.1",

--- a/web/src/assets/style/extensions/components.scss
+++ b/web/src/assets/style/extensions/components.scss
@@ -1,0 +1,23 @@
+.m-modal {
+  .m-modal-content {
+    @apply bg-secondary text-primary #{!important};
+  }
+
+  a {
+    @apply form-button mt-2 #{!important};
+
+    &.m-by {
+      @apply mt-4 #{!important};
+    }
+    &:hover {
+      opacity: 1 !important;
+    }
+  }
+
+  a,
+  p,
+  span,
+  strong {
+    @apply font-body #{!important};
+  }
+}

--- a/web/src/assets/style/main.scss
+++ b/web/src/assets/style/main.scss
@@ -1,6 +1,7 @@
 @tailwind base;
 
 @tailwind components;
+@import '../style/extensions/components.scss';
 
 @tailwind utilities;
 

--- a/web/src/components/MetaInfo.vue
+++ b/web/src/components/MetaInfo.vue
@@ -16,4 +16,4 @@ export default {
 }
 </script>
 
-<style lang="scss"></style>
+<style></style>

--- a/web/src/components/PostCard.vue
+++ b/web/src/components/PostCard.vue
@@ -62,10 +62,11 @@ export default {
   },
   methods: {
     timeToRead(content) {
-      return readingTime(content)
+      const plainText = this.$toPlainText(content)
+      return readingTime(plainText)
     }
   }
 }
 </script>
 
-<style lang="scss"></style>
+<style></style>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -10,6 +10,8 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 import '@deckdeckgo/highlight-code'
 import { applyPolyfills, defineCustomElements } from '@deckdeckgo/highlight-code/dist/loader'
 
+import mailgo from 'mailgo'
+
 import { faGithub, faDev, faTwitter, faLinkedin } from '@fortawesome/free-brands-svg-icons'
 import {
   faHome,
@@ -44,6 +46,7 @@ library.add(
 )
 // Import image url builder
 import urlForImage from './utils/urlForImage'
+import toPlainText from './utils/toPlainText'
 
 import VueYoutube from 'vue-youtube'
 
@@ -68,8 +71,14 @@ export default function(Vue, { head }) {
   head.meta.push({
     name: 'keywords',
     content: clientConfig.siteInfo.keywords.join(),
-    vmid: 'keywords'
+    key: 'keywords'
   })
+
+  if (process.isClient) {
+    mailgo({
+      validateEmail: true
+    })
+  }
 
   Vue.use(VueYoutube)
 
@@ -80,4 +89,5 @@ export default function(Vue, { head }) {
 
   // Inject global image URL builder
   Vue.prototype.$urlForImage = urlForImage
+  Vue.prototype.$toPlainText = toPlainText
 }

--- a/web/src/pages/About.vue
+++ b/web/src/pages/About.vue
@@ -20,12 +20,9 @@
             :alt="$page.about.mainImage.alt"
           ></g-image>
           <div
-            class="w-full md:w-2/3 border rounded-md border-primary p-4 flex flex-col justify-between leading-normal"
+            class="flex flex-col justify-center w-full md:w-2/3 bg-secondary shadow-lg rounded-md p-4 mb-2 leading-normal"
           >
-            <div class="mb-2">
-              <div class="font-bold text-xl mb-2"></div>
-              <block-content :blocks="$page.about._rawBiography" />
-            </div>
+            <block-content :blocks="$page.about._rawBiography" />
           </div>
         </div>
         <div class="flex w-full flex-col items-center">
@@ -83,8 +80,17 @@ import BlockContent from '~/components/BlockContent'
 import Timeline from '~/components/Timeline'
 
 export default {
-  metaInfo: {
-    title: 'About Me'
+  metaInfo() {
+    return {
+      title: 'About Me',
+      meta: [
+        {
+          key: 'description',
+          name: 'description',
+          content: this.$toPlainText(this.$page.about._rawBiography)
+        }
+      ]
+    }
   },
   components: {
     BlockContent,

--- a/web/src/pages/Contact.vue
+++ b/web/src/pages/Contact.vue
@@ -59,8 +59,17 @@ import BlockContent from '~/components/BlockContent'
 import ContactLink from '~/components/ContactLink'
 
 export default {
-  metaInfo: {
-    title: 'Contact'
+  metaInfo() {
+    return {
+      title: 'Contact',
+      meta: [
+        {
+          key: 'description',
+          name: 'description',
+          content: this.$toPlainText(this.$page.contact._rawInformation)
+        }
+      ]
+    }
   },
   components: {
     ContactForm,

--- a/web/src/pages/Index.vue
+++ b/web/src/pages/Index.vue
@@ -4,8 +4,10 @@
       <div class="title-container flex items-center">
         <h1 class="font-display uppercase title-animated">{{ $page.home.introHeader }}</h1>
       </div>
-      <div class="flex flex-row text-lg md:max-w-1/2 py-4">
-        <block-content :blocks="$page.home._rawIntroBody" />
+      <div class="flex flex-row text-lg md:max-w-1/2 pt-8 pb-4">
+        <div class="flex flex-col justify-center bg-secondary shadow-lg rounded-md p-4">
+          <block-content :blocks="$page.home._rawIntroBody" />
+        </div>
       </div>
       <!--
         Need to take a couple photos and have one animate up only once when the site is loaded and have that tracked.
@@ -159,6 +161,7 @@ export default {
       title: 'Software Engineer',
       meta: [
         {
+          key: 'description',
           name: 'description',
           content: this.$page.metadata.siteInfo.description
         }

--- a/web/src/templates/SanityPost.vue
+++ b/web/src/templates/SanityPost.vue
@@ -50,7 +50,7 @@ import BlockContent from '~/components/BlockContent'
 import MetaInfo from '~/components/MetaInfo'
 import Categories from '~/components/Categories'
 import ArrowLink from '~/components/ArrowLink'
-import readingTime from '../utils/timeToRead.js'
+import readingTime from '../utils/timeToRead'
 
 export default {
   components: {
@@ -61,7 +61,19 @@ export default {
   },
   metaInfo() {
     return {
-      title: this.$page.post.title
+      title: this.$page.post.title,
+      meta: [
+        {
+          key: 'description',
+          name: 'description',
+          content: this.$toPlainText(this.$page.post._rawExcerpt)
+        },
+        {
+          key: 'keywords',
+          name: 'keywords',
+          content: this.$page.post.categories.map(category => category.title).join(',')
+        }
+      ]
     }
   },
   computed: {
@@ -83,7 +95,8 @@ export default {
       return item == null || item == undefined
     },
     timeToRead(content) {
-      return readingTime(content)
+      const plainText = this.$toPlainText(content)
+      return readingTime(plainText)
     }
   }
 }

--- a/web/src/templates/SanityProject.vue
+++ b/web/src/templates/SanityProject.vue
@@ -50,7 +50,7 @@ import BlockContent from '~/components/BlockContent'
 import MetaInfo from '~/components/MetaInfo'
 import Categories from '~/components/Categories'
 import ArrowLink from '~/components/ArrowLink'
-import readingTime from '../utils/timeToRead.js'
+import readingTime from '../utils/timeToRead'
 
 export default {
   components: {
@@ -64,6 +64,7 @@ export default {
       title: this.$page.project.title,
       meta: [
         {
+          key: 'description',
           name: 'description',
           content: this.$page.project.description
         }
@@ -95,7 +96,8 @@ export default {
       return item == null || item == undefined
     },
     timeToRead(content) {
-      return readingTime(content)
+      const plainText = this.$toPlainText(content)
+      return readingTime(plainText)
     }
   }
 }

--- a/web/src/utils/toPlainText.js
+++ b/web/src/utils/toPlainText.js
@@ -1,0 +1,22 @@
+//utility used in order to convert sanity block content into plain text
+
+const toPlainText = (blocks = []) => {
+  return (
+    blocks
+      // loop through each block
+      .map(block => {
+        // if it's not a text block with children,
+        // return nothing
+        if (block._type !== 'block' || !block.children) {
+          return ''
+        }
+        // loop through the children spans, and join the
+        // text strings
+        return block.children.map(child => child.text).join('')
+      })
+      // join the paragraphs leaving split by two linebreaks
+      .join('\n\n')
+  )
+}
+
+export default toPlainText

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -2,6 +2,7 @@ const plugin = require('tailwindcss/plugin')
 
 module.exports = {
   // purge: ['./src/**/*.html', './src/**/*.vue', './src/**/*.js'],
+  purge: false,
   theme: {
     screens: {
       xs: '375px',


### PR DESCRIPTION
Installed, implmented, and overrided styling for the mailgo modules. Updated several components to implement a toPlainText prototype from Sanity's recommendation to not only calculate read time more accurately, but for any other instances where I need a block to plain text conversion. Updated home page and about page components to wrap text in the same card styling.